### PR TITLE
include note tags in the export

### DIFF
--- a/evernote_to_sqlite/utils.py
+++ b/evernote_to_sqlite/utils.py
@@ -72,18 +72,11 @@ def save_note(db, note):
 def save_tag(db, tag, note_id):
     if tag is None:
         return
-    md5 = hashlib.md5(tag.encode()).hexdigest()
-    row = {
-        "md5": md5,
-        "name": tag,
-    }
-    db["tags"].insert(row, pk="md5", alter=True, replace=True)
-
     rel = {
         "note_id": note_id,
-        "tag_md5": md5,
+        "tag": tag,
     }
-    db["notes_tags"].insert(rel, pk={"note_id", "tag_md5"}, alter=True, replace=True)
+    db["notes_tags"].insert(rel, pk={"note_id", "tag"}, alter=True, replace=True)
     return
 
 

--- a/evernote_to_sqlite/utils.py
+++ b/evernote_to_sqlite/utils.py
@@ -66,6 +66,25 @@ def save_note(db, note):
             foreign_keys=("note_id", "resource_id"),
             replace=True,
         )
+    for tag in note.findall("tag"):
+        save_tag(db, tag.text, note_id)
+
+def save_tag(db, tag, note_id):
+    if tag is None:
+        return
+    md5 = hashlib.md5(tag.encode()).hexdigest()
+    row = {
+        "md5": md5,
+        "name": tag,
+    }
+    db["tags"].insert(row, pk="md5", alter=True, replace=True)
+
+    rel = {
+        "note_id": note_id,
+        "tag_md5": md5,
+    }
+    db["notes_tags"].insert(rel, pk={"note_id", "tag_md5"}, alter=True, replace=True)
+    return
 
 
 def save_resource(db, resource):


### PR DESCRIPTION
When parsing the Evernote `<note>` elements, the script will now also parse any nested `<tag>` elements, writing them out into a separate sqlite table.

Here is an example of how to query the data after the script has run:
```
select notes.*,
	(select group_concat(tag) from notes_tags where notes_tags.note_id=notes.id) as tags
from notes;
```

My .enex source file is 3+ years old so I am assuming the structure hasn't changed.  Interestingly, my _notebook names_ show up in the _tags_ list where the tag name is prefixed with `notebook_`, so this could maybe help work around the first limitation mentioned in the [evernote-to-sqlite blog post](https://simonwillison.net/2020/Oct/16/building-evernote-sqlite-exporter/).
